### PR TITLE
Format Depth decimals for Time and Cross section correlation plots 

### DIFF
--- a/src/plot.py
+++ b/src/plot.py
@@ -679,7 +679,7 @@ def northeast(solutionspath=None, tl=None, filepath='northeast.png'):
     """
     @ticker.FuncFormatter
     def major_formatter(x, pos):
-        return str(-x) if x < 0 else str(x)
+        return '{:.1f}'.format(abs(x))
 
     solutionspath=os.path.join(config.outputdir,('solutions' if not config.revise else 'solutions.revise'))
     tl=config.besttl
@@ -824,7 +824,7 @@ def time(correlationspath=None, filepath='time.png'):
     """
     @ticker.FuncFormatter
     def major_formatter(x, pos):
-        return str(-x) if x < 0 else str(x)
+        return '{:.1f}'.format(abs(x))
     
     correlationspath=os.path.join(config.outputdir,('correlations' if not config.revise else 'correlations.revise'))
     tl=config.besttl


### PR DESCRIPTION
This is a minor fix to make the time and cross section correlation plots cleaner.

Before
![image](https://github.com/user-attachments/assets/77ea3d92-3491-4c4b-ad8b-cee25a53fe42)

After
![image](https://github.com/user-attachments/assets/fad9e77e-abee-4d2b-9138-ebc7a268ba96)
