### PR TITLE
Add Deviatoric/Isotropic option to config

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -182,6 +182,21 @@ def time(func):
         logger.info('Function \'{}\' executed {} seconds'.format(func.__name__,round(tm.time()-start,2)))
     return inner
 
+def get_keyinv(config):
+    keyinv = 2
+    try:
+        keyinv = config['Inversion']['Keyinv']
+    # Allow undefined keyinv in config for backwards compatability.
+    except KeyError:
+        logger.info(f"'keyinv' not found in config.")
+        logger.info(f"Using default: 2 (deviatoric)")
+    
+    if keyinv not in [1, 2]:
+        logger.info(f"Invalid keyinv value '{keyinv}', expected int: 1 (iso) or 2 (dev).")
+        logger.info(f"Using default: 2 (deviatoric)")
+        keyinv = 2
+    return keyinv
+
 # add more properties to Trace
 Trace.enabled=False # enabled for processing
 Trace.distance=None

--- a/src/config.py
+++ b/src/config.py
@@ -188,11 +188,11 @@ def get_keyinv(config):
         keyinv = config['Inversion']['Keyinv']
     # Allow undefined keyinv in config for backwards compatability.
     except KeyError:
-        logger.info(f"'keyinv' not found in config.")
+        logger.info(f"'Keyinv' not found in config.")
         logger.info(f"Using default: 2 (deviatoric)")
     
     if keyinv not in [1, 2]:
-        logger.info(f"Invalid keyinv value '{keyinv}', expected int: 1 (iso) or 2 (dev).")
+        logger.info(f"Invalid 'Keyinv' value '{keyinv}', expected int: 1 (iso) or 2 (dev).")
         logger.info(f"Using default: 2 (deviatoric)")
         keyinv = 2
     return keyinv

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -341,6 +341,9 @@ Inversion:
   # Path to inversion executable. Unless you know what 
   # you are doing, you won't need to change it.
   ExePath: core/inversion/isola
+  
+  # ISOTROPIC = 1, DEVIATORIC = 2, 
+  Keyinv: 2 
 
 # This service is used to provide Gisola with a catalog of 
 # seismic events, either for real-time or past-time operation.  

--- a/src/core/inversion/isola15.f90
+++ b/src/core/inversion/isola15.f90
@@ -20,6 +20,8 @@
       INTEGER I, IA, IBEGIN, IBEST, ICOM, ID1, ID2, IERR, IM, IOPTSHF, IR, IR1, IR2
       INTEGER IRECALL, IS1, IS2, ISELECT, ISEQ, ISEQM, ISEQUEN, ISH, ISOUR, ISOURMAX, ISUB, ITIM, JM
       INTEGER KEYGPS, KEYINV, N, NFILE, NROT, NUMF1, NUMF2, NUSE
+      INTEGER NUM_ARGS
+      CHARACTER(LEN=100) :: arg
 
 !     POZOR - pokud se zmeni pocet bodu pri vypocet VR tak zmenit take manidata15.inc
 !     !!!!!!!!!!!!!!!!!!!!
@@ -125,6 +127,18 @@
 
       NTIM = NUM_OF_TIME_SAMPLES
 
+      ! Read custom KEYINV if it's passed as a 9th argument
+      KEYINV = 2 ! default to DEVIATORIC
+      NUM_ARGS = COMMAND_ARGUMENT_COUNT()
+      IF (NUM_ARGS > 8) THEN ! 8 arguments are used by the default isola.py call
+         CALL GET_COMMAND_ARGUMENT(9, arg) ! the 9th argument is KEYINV
+         READ(arg, *) KEYINV
+         IF (KEYINV /= 1 .AND. KEYINV /= 2) THEN
+            WRITE(*, *) "Warning: Invalid KEYINV value, expected 1 or 2. Using default value 2."
+            KEYINV = 2
+         END IF
+      END IF
+
       allstatfile="allstat.dat"
       inpinvfile="inpinv.dat"
       grdatfile="grdat.hed"
@@ -208,7 +222,6 @@
       end do
 93 close(110)
 
-      KEYINV=2 !fixed to deviatoric type
       DT=TL/8192.
       ISOURMAX=NS
       ISUBMAX=1

--- a/src/isola.py
+++ b/src/isola.py
@@ -600,6 +600,7 @@ def gatherResults(cfg=None, evt=None, workdir=None, bestinvdir=None, revise=Fals
             elif line.startswith(' moment (Nm)'):
                 mag.mag=float(content[i+1].split()[2])
                 mt.scalar_moment=float(line.split()[2])
+                mt.iso = float(content[i+2].split()[3])/100.0
                 mt.double_couple=float(content[i+3].split()[3])/100.0
                 mt.clvd=float(content[i+4].split()[3])/100.0
                 nd=content[i+5].split() + content[i+6].split()

--- a/src/isola.py
+++ b/src/isola.py
@@ -384,7 +384,7 @@ def calculateInversions():
 
                 os.makedirs(os.path.join(config.inversiondir,invdir))
 
-                command='{} {} {} {} {} {} {} {} {}\n'.format(os.path.join(os.getcwd(),config.cfg['Inversion']['ExePath']),
+                command='{} {} {} {} {} {} {} {} {} {} \n'.format(os.path.join(os.getcwd(),config.cfg['Inversion']['ExePath']),
                             os.path.join('..', '..','allstat', allstat),
                             os.path.join('..', '..','inpinv', inpinv),
                             os.path.join('..', '..','grdat', 'grdat'+igrdat+'.hed'),
@@ -392,8 +392,9 @@ def calculateInversions():
                             os.path.join('..', '..','crustals', 'crustal'+icrustal+'.dat'),
                             os.path.join('..', '..','sources', 'grid'+igrid, 'source'+isource+'.dat'),
                             os.path.join('..', '..','station.dat'),
-                            os.path.join('..', '..','raw', igrdat))
-                #print(command)
+                            os.path.join('..', '..','raw', igrdat),
+                            str(config.get_keyinv(config.cfg))
+                            )
 
                 proc=subprocess.Popen(command, cwd=os.path.join(config.inversiondir, invdir), shell=True, universal_newlines=True,stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
                 out,err=proc.communicate()
@@ -413,16 +414,17 @@ def calculateRevisedInversions(_cfg,logger,workdir,bestinvdir, restore=False):
     for grhes in sorted(glob.glob(os.path.join(workdir,'greens',grhes))):
         isource= grhes.split('.')[-2]
 
-        command='{} {} {} {} {} {} {} {} {}\n'.format(os.path.join(os.getcwd(),_cfg['Inversion']['ExePath']),
-                os.path.join('..', '..','allstat', allstat),
+        command='{} {} {} {} {} {} {} {} {} {} \n'.format(os.path.join(os.getcwd(),_cfg['Inversion']['ExePath']),
+                os.path.join('..', '..','allstat', allstat),    
                 os.path.join('..', '..','inpinv', inpinv),
                 os.path.join('..', '..','grdat', 'grdat'+igrdat+'.hed'),
                 os.path.join('..', '..','greens', os.path.basename(grhes)),
                 os.path.join('..', '..','crustals', 'crustal'+icrustal+'.dat'),
                 os.path.join('..', '..','sources', 'grid'+igrid, 'source'+isource+'.dat'),
                 os.path.join('..', '..','station.dat'),
-                os.path.join('..', '..','raw', igrdat))
-        #print(command)
+                os.path.join('..', '..','raw', igrdat),
+                str(config.get_keyinv(_cfg)))
+
         invdir='{}.{}.{}.{}.{}.{}'.format(allstat.split('.')[0][7:], 
                inpinv.split('.')[0][6:], icrustal, igrdat, igrid, isource)
 

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -2,7 +2,7 @@
 Version: 1.0
 
 # Directory where the process is being performed
-WorkDir: ../fanis/dev-iso-tests
+WorkDir: ../test/results
 
 # The Inventory Service supports FDSNWS-station only and file in XML format (as mentioned in ObsPy documentation)
 Inventory:

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -2,7 +2,7 @@
 Version: 1.0
 
 # Directory where the process is being performed
-WorkDir: ../test/results
+WorkDir: ../fanis/dev-iso-tests
 
 # The Inventory Service supports FDSNWS-station only and file in XML format (as mentioned in ObsPy documentation)
 Inventory:
@@ -73,6 +73,9 @@ Inversion:
     - [6.1, 9.0, [0.007, 0.008, 0.02, 0.03]]
 
   ExePath: core/inversion/isola
+  
+  # ISOTROPIC = 1, DEVIATORIC = 2
+  Keyinv: 2
 
 # This service provides gisola with event info
 Event:


### PR DESCRIPTION
This PR introduces changes to read the Keyinv (dev/iso) parameter directly from the Gisola configuration file. The default value of Keyinv is set to 2 (deviatoric) when it is not explicitly defined in the config, to ensure backwards compatibility with older configuration files.